### PR TITLE
Remove dub.sh from blocklist

### DIFF
--- a/blocklist.txt
+++ b/blocklist.txt
@@ -9271,7 +9271,6 @@ zekur.nl##body:style(overflow: auto!important)
 ||duanat.com^
 ||duapp.com^
 ||duapps.com^
-||dub.sh^
 ||dubox.com^
 ||duckduckgo.com^$removeparam=ia
 ||duckduckgo.com^$removeparam=t

--- a/domains.txt
+++ b/domains.txt
@@ -8444,7 +8444,6 @@ dualstack.ichnaea-web-323206729.eu-west-1.elb.amazonaws.com
 duanat.com
 duapp.com
 duapps.com
-dub.sh
 dubox.com
 duelz.com
 dugbvb.com

--- a/little-snitch-blocklist.lsrules
+++ b/little-snitch-blocklist.lsrules
@@ -8442,7 +8442,6 @@
         "duanat.com",
         "duapp.com",
         "duapps.com",
-        "dub.sh",
         "dubox.com",
         "duelz.com",
         "dugbvb.com",

--- a/pihole-blocklist.txt
+++ b/pihole-blocklist.txt
@@ -8444,7 +8444,6 @@
 0.0.0.0 duanat.com
 0.0.0.0 duapp.com
 0.0.0.0 duapps.com
-0.0.0.0 dub.sh
 0.0.0.0 dubox.com
 0.0.0.0 duelz.com
 0.0.0.0 dugbvb.com

--- a/rpz-blocklist.txt
+++ b/rpz-blocklist.txt
@@ -8444,7 +8444,6 @@ dualstack.ichnaea-web-323206729.eu-west-1.elb.amazonaws.com CNAME .
 duanat.com CNAME .
 duapp.com CNAME .
 duapps.com CNAME .
-dub.sh CNAME .
 dubox.com CNAME .
 duelz.com CNAME .
 dugbvb.com CNAME .

--- a/unbound-blocklist.txt
+++ b/unbound-blocklist.txt
@@ -8444,7 +8444,6 @@ local-zone: "dualstack.ichnaea-web-323206729.eu-west-1.elb.amazonaws.com." alway
 local-zone: "duanat.com." always_null
 local-zone: "duapp.com." always_null
 local-zone: "duapps.com." always_null
-local-zone: "dub.sh." always_null
 local-zone: "dubox.com." always_null
 local-zone: "duelz.com." always_null
 local-zone: "dugbvb.com." always_null


### PR DESCRIPTION
Hey team! Founder of [Dub](https://dub.co/) here.

`dub.sh` is our default short link domain on Dub (similar to `bit.ly`) – we monitor this domain regularly to make sure there are no phishing/spam links that are added (view our [Terms](https://dub.co/legal/terms)), and you can use our [Report Abuse form](https://dub.co/legal/abuse) to report any bad links.

Thank you!