### PR TITLE
Remove dub.co

### DIFF
--- a/blocklist.txt
+++ b/blocklist.txt
@@ -9281,7 +9281,6 @@ zekur.nl##body:style(overflow: auto!important)
 ||duanat.com^
 ||duapp.com^
 ||duapps.com^
-||dub.co^
 ||dub.sh^
 ||dubox.com^
 ||duckduckgo.com^$removeparam=ia

--- a/domains.txt
+++ b/domains.txt
@@ -8450,7 +8450,6 @@ dualstack.ichnaea-web-323206729.eu-west-1.elb.amazonaws.com
 duanat.com
 duapp.com
 duapps.com
-dub.co
 dub.sh
 dubox.com
 duelz.com

--- a/little-snitch-blocklist.lsrules
+++ b/little-snitch-blocklist.lsrules
@@ -8448,7 +8448,6 @@
         "duanat.com",
         "duapp.com",
         "duapps.com",
-        "dub.co",
         "dub.sh",
         "dubox.com",
         "duelz.com",

--- a/pihole-blocklist.txt
+++ b/pihole-blocklist.txt
@@ -8450,7 +8450,6 @@
 0.0.0.0 duanat.com
 0.0.0.0 duapp.com
 0.0.0.0 duapps.com
-0.0.0.0 dub.co
 0.0.0.0 dub.sh
 0.0.0.0 dubox.com
 0.0.0.0 duelz.com

--- a/rpz-blocklist.txt
+++ b/rpz-blocklist.txt
@@ -8450,7 +8450,6 @@ dualstack.ichnaea-web-323206729.eu-west-1.elb.amazonaws.com CNAME .
 duanat.com CNAME .
 duapp.com CNAME .
 duapps.com CNAME .
-dub.co CNAME .
 dub.sh CNAME .
 dubox.com CNAME .
 duelz.com CNAME .

--- a/unbound-blocklist.txt
+++ b/unbound-blocklist.txt
@@ -8450,7 +8450,6 @@ local-zone: "dualstack.ichnaea-web-323206729.eu-west-1.elb.amazonaws.com." alway
 local-zone: "duanat.com." always_null
 local-zone: "duapp.com." always_null
 local-zone: "duapps.com." always_null
-local-zone: "dub.co." always_null
 local-zone: "dub.sh." always_null
 local-zone: "dubox.com." always_null
 local-zone: "duelz.com." always_null


### PR DESCRIPTION
Hey @ph00lt0 ! Steven from [Dub](https://dub.co/) here again. Would love to be able to remove `dub.co` from the blocklist.

While `dub.sh` is our short link domain (and I understand the decision to not remove it from the blocklist in #123), `dub.co` is our main website domain and is not used for any link shortening purposes – both internally and externally. Would really appreciate it if we can get it removed from the blocklist please!

Thank you!