### PR TITLE
Remove yellowball.fm

### DIFF
--- a/blocklist.txt
+++ b/blocklist.txt
@@ -22022,7 +22022,6 @@ zekur.nl##body:style(overflow: auto!important)
 ||yeelight.com^
 ||yeelyn.com^
 ||yellow.co-operativebank.co.uk^
-||yellowball.fm^
 ||yellowpages.com^
 ||yellowpages.pl^
 ||yellowpageseu.net^


### PR DESCRIPTION
I bought the domain a little over a year ago for my podcast hosting service. I was searching around and found it on the list.